### PR TITLE
fix(seo): social previews and canonical site URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ CLOUDFRONT_DOMAIN=
 CLOUDFRONT_KEY_PAIR_ID=
 CLOUDFRONT_PRIVATE_KEY=
 
+# Canonical site URL for Open Graph, canonical links, feeds (include scheme; match www vs apex)
+NEXT_PUBLIC_SITE_URL=
+
 # Optional analytics
 NEXT_PUBLIC_GOOGLE_ANALYTICS=
 NEXT_PUBLIC_CLARITY_APP_CODE=

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Modern portfolio built with Next.js App Router, MDX blogging, a custom music sho
 - Per-route error boundaries powered by a shared `RouteError` component (captures to Sentry in prod)
 - Typed env schema (`src/env.ts`) validated with Zod; boot fails fast on missing required keys
 - In-memory rate limiting on `/api/reactions` (30/min) and `/api/sendMail` (5/hour); returns 429 + `Retry-After`
-- SEO metadata and OpenGraph image routes
+- SEO metadata and OpenGraph image routes; canonical URLs use `getSiteUrl()` (`src/lib/site-url.ts`). Set `NEXT_PUBLIC_SITE_URL` in production to match your Vercel primary domain so Open Graph, canonical links, RSS, sitemap, and JSON-LD stay aligned
 - MDX blog pipeline with:
   - table of contents (server-extracted headings, no DOM polling)
   - reading progress bar
@@ -88,6 +88,9 @@ AWS_BUCKET_NAME=
 CLOUDFRONT_DOMAIN=
 CLOUDFRONT_KEY_PAIR_ID=
 CLOUDFRONT_PRIVATE_KEY=
+
+# Optional: canonical public URL (no trailing slash); match Vercel primary domain
+NEXT_PUBLIC_SITE_URL=
 
 # Optional analytics
 NEXT_PUBLIC_GOOGLE_ANALYTICS=

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -92,10 +92,6 @@ const nextConfig = {
             key: 'Strict-Transport-Security',
             value: 'max-age=63072000; includeSubDomains; preload',
           },
-          {
-            key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable',
-          },
         ],
       },
     ];

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -5,11 +5,14 @@ import Layout from '@/app/components/Layout';
 import Skills from '@/app/components/Skills';
 import Experience from '@/app/components/Experience';
 import { GitHubCalendar } from '@/app/components';
+import { getSiteUrl } from '@/lib/site-url';
 
 import styles from '../styles/sections/aboutSection.module.scss';
 
+const siteUrl = getSiteUrl();
+
 export const metadata: Metadata = {
-  metadataBase: new URL('https://akshaygupta.live'),
+  metadataBase: new URL(siteUrl),
   title: 'About | Akshay Gupta',
   description:
     'Learn about my journey as a Senior Staff Engineer at PeopleGrove, my skills, experience, and what drives me in web development.',
@@ -18,7 +21,7 @@ export const metadata: Metadata = {
     title: 'About Akshay Gupta | Full-Stack Developer',
     description:
       'Learn about my journey as a Senior Staff Engineer at PeopleGrove, my skills, experience, and what drives me in web development.',
-    url: 'https://akshaygupta.live/about',
+    url: `${siteUrl}/about`,
     siteName: 'Akshay Gupta',
     locale: 'en_US',
     images: [
@@ -40,7 +43,7 @@ export const metadata: Metadata = {
     images: ['/about/opengraph-image'],
   },
   alternates: {
-    canonical: 'https://akshaygupta.live/about',
+    canonical: `${siteUrl}/about`,
   },
 };
 
@@ -104,8 +107,8 @@ export default function About() {
         name: 'PeopleGrove',
         url: 'https://www.peoplegrove.com',
       },
-      url: 'https://akshaygupta.live',
-      image: 'https://akshaygupta.live/images/about-me.webp',
+      url: siteUrl,
+      image: `${siteUrl}/images/about-me.webp`,
       description: `Senior Staff Engineer at PeopleGrove with over ${yearsOfExperience} years of experience in web development.`,
       sameAs: [
         'https://github.com/gupta-akshay',

--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -10,8 +10,12 @@ export const size = {
   height: 630,
 };
 
-export default async function Image({ params }: { params: { slug: string } }) {
-  const slug = (await params).slug;
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
 
   if (!slug) {
     return new ImageResponse(
@@ -123,9 +127,9 @@ export async function generateStaticParams() {
 export async function generateImageMetadata({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }) {
-  const slug = (await params).slug;
+  const { slug } = await params;
 
   if (!slug) {
     return [

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import ReadingProgressBar from '@/app/components/ReadingProgressBar';
 import MermaidRenderer from '@/app/components/MermaidRenderer';
 import TableOfContentsMDX from './TableOfContentsMDX';
 import { getBlogBySlug, getAllBlogs, getBlogHeadings } from '@/lib/mdx';
+import { getSiteUrl } from '@/lib/site-url';
 import { formatDate } from '@/app/utils';
 import { logger } from '@/app/utils/logger';
 
@@ -53,33 +54,34 @@ const SingleBlogPage = async ({ params }: SingleBlogPageProps) => {
 
   const readingTime = post?.readingTime ?? '';
   const headings = getBlogHeadings(slug);
+  const siteUrl = getSiteUrl();
 
-  const imageUrl = metadata.coverImage || '/images/about-me.webp';
+  const ogImageUrl = `${siteUrl}/blog/${slug}/opengraph-image`;
 
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'BlogPosting',
     headline: metadata.title,
     description: metadata.excerpt || metadata.title,
-    image: `https://akshaygupta.live${imageUrl}`,
+    image: ogImageUrl,
     datePublished: metadata.publishedAt,
     dateModified: metadata.publishedAt,
     author: {
       '@type': 'Person',
       name: metadata.author.name,
-      url: 'https://akshaygupta.live/about',
+      url: `${siteUrl}/about`,
     },
     publisher: {
       '@type': 'Organization',
       name: 'Akshay Gupta',
       logo: {
         '@type': 'ImageObject',
-        url: 'https://akshaygupta.live/icon?size=192',
+        url: `${siteUrl}/icon?size=192`,
       },
     },
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': `https://akshaygupta.live/blog/${slug}`,
+      '@id': `${siteUrl}/blog/${slug}`,
     },
   };
 
@@ -89,7 +91,7 @@ const SingleBlogPage = async ({ params }: SingleBlogPageProps) => {
       <MermaidRenderer />
       <TableOfContentsMDX headings={headings} />
       <SocialShare
-        url={`https://akshaygupta.live/blog/${slug}`}
+        url={`${siteUrl}/blog/${slug}`}
         title={metadata.title}
         description={metadata.excerpt || metadata.title}
       />
@@ -169,6 +171,8 @@ const SingleBlogPage = async ({ params }: SingleBlogPageProps) => {
 export async function generateMetadata({
   params,
 }: SingleBlogPageProps): Promise<Metadata> {
+  const siteUrl = getSiteUrl();
+
   try {
     const { slug } = await params;
     const post = await getBlogBySlug(slug);
@@ -177,47 +181,36 @@ export async function generateMetadata({
       return {
         title: 'Post Not Found | Akshay Gupta',
         description: `The blog post you're looking for does not exist`,
-        metadataBase: new URL('https://akshaygupta.live'),
+        metadataBase: new URL(siteUrl),
       };
     }
 
     const { metadata } = post;
-    const imageUrl = metadata.coverImage || '/images/about-me.webp';
     const description = metadata.excerpt || metadata.title;
 
     return {
       title: `${metadata.title} | Akshay Gupta's Blog`,
-      description: description,
-      metadataBase: new URL('https://akshaygupta.live'),
+      description,
+      metadataBase: new URL(siteUrl),
       openGraph: {
         type: 'article',
         title: metadata.title,
-        description: description,
-        url: `https://akshaygupta.live/blog/${slug}`,
+        description,
+        url: `${siteUrl}/blog/${slug}`,
         siteName: 'Akshay Gupta',
         locale: 'en_US',
         publishedTime: metadata.publishedAt,
         modifiedTime: metadata.publishedAt,
         authors: [metadata.author.name],
-        images: [
-          {
-            url: imageUrl,
-            width: 1200,
-            height: 630,
-            alt: metadata.title,
-            type: 'image/png',
-          },
-        ],
       },
       twitter: {
         card: 'summary_large_image',
         title: metadata.title,
-        description: description,
-        images: [imageUrl],
+        description,
         creator: '@ashay_music',
       },
       alternates: {
-        canonical: `https://akshaygupta.live/blog/${slug}`,
+        canonical: `${siteUrl}/blog/${slug}`,
       },
     };
   } catch (error) {
@@ -225,7 +218,7 @@ export async function generateMetadata({
     return {
       title: 'Error | Akshay Gupta',
       description: 'An error occurred while loading this blog post',
-      metadataBase: new URL('https://akshaygupta.live'),
+      metadataBase: new URL(siteUrl),
     };
   }
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -4,9 +4,12 @@ import Layout from '@/app/components/Layout';
 import BlogTileMDX from '@/app/components/BlogTileMDX';
 import LoadingIndicator from '@/app/components/LoadingIndicator';
 import { getAllBlogs } from '@/lib/mdx';
+import { getSiteUrl } from '@/lib/site-url';
+
+const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://akshaygupta.live'),
+  metadataBase: new URL(siteUrl),
   title: 'Blog | Akshay Gupta',
   description:
     'Read my latest thoughts and insights about web development, technology, and software engineering.',
@@ -15,7 +18,7 @@ export const metadata: Metadata = {
     title: 'Blog | Akshay Gupta',
     description:
       'Read my latest thoughts and insights about web development, technology, and software engineering.',
-    url: 'https://akshaygupta.live/blog',
+    url: `${siteUrl}/blog`,
     siteName: 'Akshay Gupta',
     locale: 'en_US',
     images: [
@@ -37,7 +40,7 @@ export const metadata: Metadata = {
     creator: '@ashay_music',
   },
   alternates: {
-    canonical: 'https://akshaygupta.live/blog',
+    canonical: `${siteUrl}/blog`,
   },
 };
 
@@ -48,28 +51,28 @@ async function BlogPosts() {
     '@context': 'https://schema.org',
     '@type': 'Blog',
     name: 'Akshay Gupta Blog',
-    url: 'https://akshaygupta.live/blog',
+    url: `${siteUrl}/blog`,
     description:
       'Read my latest thoughts and insights about web development and technology.',
     author: {
       '@type': 'Person',
       name: 'Akshay Gupta',
-      url: 'https://akshaygupta.live',
+      url: siteUrl,
     },
     blogPost: posts.map((post) => ({
       '@type': 'BlogPosting',
       headline: post.metadata.title,
-      url: `https://akshaygupta.live/blog/${post.slug}`,
+      url: `${siteUrl}/blog/${post.slug}`,
       datePublished: post.metadata.publishedAt,
       dateModified: post.metadata.publishedAt,
       author: {
         '@type': 'Person',
         name: 'Akshay Gupta',
-        url: 'https://akshaygupta.live',
+        url: siteUrl,
       },
       mainEntityOfPage: {
         '@type': 'WebPage',
-        '@id': `https://akshaygupta.live/blog/${post.slug}`,
+        '@id': `${siteUrl}/blog/${post.slug}`,
       },
     })),
   };

--- a/src/app/contact/layout.tsx
+++ b/src/app/contact/layout.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from 'next';
+import { getSiteUrl } from '@/lib/site-url';
+
+const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://akshaygupta.live'),
+  metadataBase: new URL(siteUrl),
   title: 'Contact | Akshay Gupta',
   description:
     'Get in touch with me for collaboration opportunities, project discussions, or any questions you might have.',
@@ -10,7 +13,7 @@ export const metadata: Metadata = {
     title: 'Contact Akshay Gupta',
     description:
       'Get in touch with me for collaboration opportunities, project discussions, or any questions you might have.',
-    url: 'https://akshaygupta.live/contact',
+    url: `${siteUrl}/contact`,
     siteName: 'Akshay Gupta',
     locale: 'en_US',
     images: [
@@ -32,7 +35,7 @@ export const metadata: Metadata = {
     images: ['/contact/opengraph-image'],
   },
   alternates: {
-    canonical: 'https://akshaygupta.live/contact',
+    canonical: `${siteUrl}/contact`,
   },
 };
 
@@ -47,20 +50,20 @@ export default function ContactLayout({
     name: 'Contact Akshay Gupta',
     description:
       'Get in touch with me for collaboration opportunities, project discussions, or any questions you might have.',
-    url: 'https://akshaygupta.live/contact',
+    url: `${siteUrl}/contact`,
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://akshaygupta.live/contact',
+      '@id': `${siteUrl}/contact`,
     },
     author: {
       '@type': 'Person',
       name: 'Akshay Gupta',
-      url: 'https://akshaygupta.live',
+      url: siteUrl,
     },
     provider: {
       '@type': 'Organization',
       name: 'Akshay Gupta Portfolio',
-      url: 'https://akshaygupta.live',
+      url: siteUrl,
       contactPoint: {
         '@type': 'ContactPoint',
         email: 'contact@akshaygupta.live',

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,14 +1,14 @@
 import { getAllBlogs } from '@/lib/mdx';
-
-const SITE_URL = 'https://akshaygupta.live';
+import { getSiteUrl } from '@/lib/site-url';
 
 export async function GET() {
+  const siteUrl = getSiteUrl();
   const posts = await getAllBlogs();
 
   const items = posts
     .map((post) => {
       const { metadata, slug } = post;
-      const url = `${SITE_URL}/blog/${slug}`;
+      const url = `${siteUrl}/blog/${slug}`;
       const pubDate = new Date(metadata.publishedAt).toUTCString();
       const description = metadata.excerpt
         ? `<![CDATA[${metadata.excerpt}]]>`
@@ -31,10 +31,10 @@ export async function GET() {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Akshay Gupta Blog</title>
-    <link>${SITE_URL}/blog</link>
+    <link>${siteUrl}/blog</link>
     <description>Long-form notes on engineering, architecture, performance, and practical lessons from shipping production software.</description>
     <language>en-US</language>
-    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="${siteUrl}/feed.xml" rel="self" type="application/rss+xml" />
     <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
     ${items}
   </channel>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,11 +9,14 @@ import DeviconCSSLoader from './components/DeviconCSSLoader';
 import Metrics from './metrics';
 import TerminalCTA from './components/TerminalCTA';
 import { TerminalCTAProvider } from './components/TerminalCTA/TerminalCTAContext';
+import { getSiteUrl } from '@/lib/site-url';
 
 import '@fortawesome/fontawesome-svg-core/styles.css';
 import './styles/globals.scss';
 
 config.autoAddCss = false;
+
+const siteUrl = getSiteUrl();
 
 export const viewport = {
   width: 'device-width',
@@ -22,7 +25,7 @@ export const viewport = {
 };
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://akshaygupta.live'),
+  metadataBase: new URL(siteUrl),
   title: {
     default: 'Akshay Gupta | Full-Stack Web Developer',
     template: '%s | Akshay Gupta',
@@ -45,7 +48,7 @@ export const metadata: Metadata = {
     title: 'Akshay Gupta | Full-Stack Web Developer',
     description:
       'Senior Staff Engineer at PeopleGrove with over 7 years of experience in web development.',
-    url: 'https://akshaygupta.live',
+    url: siteUrl,
     locale: 'en_US',
     images: [
       {
@@ -74,7 +77,7 @@ export const metadata: Metadata = {
   },
   alternates: {
     types: {
-      'application/rss+xml': 'https://akshaygupta.live/feed.xml',
+      'application/rss+xml': `${siteUrl}/feed.xml`,
     },
   },
 };

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -3,9 +3,12 @@ import { Suspense } from 'react';
 import Layout from '@/app/components/Layout';
 import LoadingIndicator from '@/app/components/LoadingIndicator';
 import MusicTracks from '@/app/music/components/MusicTracks';
+import { getSiteUrl } from '@/lib/site-url';
+
+const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://akshaygupta.live'),
+  metadataBase: new URL(siteUrl),
   title: 'My Music | Akshay Gupta',
   description:
     'Listen to my latest remixes and music productions. Enjoy the beats!',
@@ -14,7 +17,7 @@ export const metadata: Metadata = {
     title: 'My Music | Akshay Gupta',
     description:
       'Listen to my latest remixes and music productions. Enjoy the beats!',
-    url: 'https://akshaygupta.live/music',
+    url: `${siteUrl}/music`,
     siteName: 'Akshay Gupta',
     locale: 'en_US',
     images: [
@@ -36,7 +39,7 @@ export const metadata: Metadata = {
     images: ['/music/opengraph-image'],
   },
   alternates: {
-    canonical: 'https://akshaygupta.live/music',
+    canonical: `${siteUrl}/music`,
   },
 };
 
@@ -46,15 +49,15 @@ export default function Music() {
     '@type': 'MusicPlaylist',
     name: 'Akshay Gupta Music Collection',
     description: 'Listen to my remixes and music productions. Enjoy the beats!',
-    url: 'https://akshaygupta.live/music',
+    url: `${siteUrl}/music`,
     mainEntityOfPage: {
       '@type': 'WebPage',
-      '@id': 'https://akshaygupta.live/music',
+      '@id': `${siteUrl}/music`,
     },
     creator: {
       '@type': 'Person',
       name: 'Akshay Gupta',
-      url: 'https://akshaygupta.live',
+      url: siteUrl,
     },
   };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,43 +1,45 @@
 import Image from 'next/image';
 import Layout from '@/app/components/Layout';
+import { getSiteUrl } from '@/lib/site-url';
 
 import styles from './styles/sections/homeBanner.module.scss';
 
-const jsonLd = {
-  '@context': 'https://schema.org',
-  '@type': 'Person',
-  name: 'Akshay Gupta',
-  jobTitle: 'Senior Staff Engineer',
-  worksFor: {
-    '@type': 'Organization',
-    name: 'PeopleGrove',
-    url: 'https://www.peoplegrove.com',
-  },
-  url: 'https://akshaygupta.live',
-  image: 'https://akshaygupta.live/images/home-banner.webp',
-  description:
-    'Senior Staff Engineer at PeopleGrove with over 7 years of experience in web development.',
-  sameAs: [
-    'https://github.com/gupta-akshay',
-    'https://linkedin.com/in/akshayguptaujn',
-    'https://twitter.com/ashay_music',
-  ],
-  knowsAbout: [
-    'Web Development',
-    'JavaScript',
-    'React',
-    'Node.js',
-    'TypeScript',
-    'Next.js',
-    'Postgres',
-    'ElasticSearch',
-    'Redis',
-    'RabbitMQ',
-    'Google Cloud Platform',
-  ],
-};
-
 export default function Home() {
+  const siteUrl = getSiteUrl();
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: 'Akshay Gupta',
+    jobTitle: 'Senior Staff Engineer',
+    worksFor: {
+      '@type': 'Organization',
+      name: 'PeopleGrove',
+      url: 'https://www.peoplegrove.com',
+    },
+    url: siteUrl,
+    image: `${siteUrl}/images/home-banner.webp`,
+    description:
+      'Senior Staff Engineer at PeopleGrove with over 7 years of experience in web development.',
+    sameAs: [
+      'https://github.com/gupta-akshay',
+      'https://linkedin.com/in/akshayguptaujn',
+      'https://twitter.com/ashay_music',
+    ],
+    knowsAbout: [
+      'Web Development',
+      'JavaScript',
+      'React',
+      'Node.js',
+      'TypeScript',
+      'Next.js',
+      'Postgres',
+      'ElasticSearch',
+      'Redis',
+      'RabbitMQ',
+      'Google Cloud Platform',
+    ],
+  };
+
   return (
     <Layout>
       <script

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,9 @@
 import { MetadataRoute } from 'next';
+import { getSiteUrl } from '@/lib/site-url';
 
 export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl();
+
   return {
     rules: [
       {
@@ -9,7 +12,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ['/private/', '/studio/', '/studio'],
       },
     ],
-    sitemap: 'https://akshaygupta.live/sitemap.xml',
-    host: 'https://akshaygupta.live',
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import { MetadataRoute } from 'next';
 import { getAllBlogs } from '@/lib/mdx';
 import { logger } from '@/app/utils/logger';
+import { getSiteUrl } from '@/lib/site-url';
 
 interface SitemapItem {
   url: string;
@@ -17,7 +18,7 @@ interface SitemapItem {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://akshaygupta.live';
+  const baseUrl = getSiteUrl();
 
   const staticRoutes: SitemapItem[] = [
     {

--- a/src/env.ts
+++ b/src/env.ts
@@ -19,6 +19,7 @@ const serverEnvSchema = z.object({
 });
 
 const publicEnvSchema = z.object({
+  NEXT_PUBLIC_SITE_URL: z.string().url().optional(),
   NEXT_PUBLIC_GOOGLE_ANALYTICS: z.string().optional(),
   NEXT_PUBLIC_CLARITY_APP_CODE: z.string().optional(),
 });
@@ -42,6 +43,7 @@ function parseServerEnv(): ServerEnv {
 
 function parsePublicEnv(): PublicEnv {
   const result = publicEnvSchema.safeParse({
+    NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
     NEXT_PUBLIC_GOOGLE_ANALYTICS: process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS,
     NEXT_PUBLIC_CLARITY_APP_CODE: process.env.NEXT_PUBLIC_CLARITY_APP_CODE,
   });

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,0 +1,10 @@
+/**
+ * Canonical origin for metadata, feeds, JSON-LD, and sharing URLs.
+ * Set NEXT_PUBLIC_SITE_URL on the host (e.g. https://www.akshaygupta.live) so
+ * og:url, canonical, and metadataBase match how visitors share links.
+ */
+export function getSiteUrl(): string {
+  const raw = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (raw) return raw.replace(/\/$/, '');
+  return 'https://akshaygupta.live';
+}


### PR DESCRIPTION
Remove blanket immutable Cache-Control from HTML responses so link previews can pick up updated Open Graph metadata.

Rely on blog opengraph-image PNGs for post cards; centralize absolute URLs via getSiteUrl() and optional NEXT_PUBLIC_SITE_URL (validated in env schema).

Document NEXT_PUBLIC_SITE_URL in README and .env.example.