### PR TITLE
feat: add dedicated /resume page with print-ready CV layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Modern portfolio built with Next.js App Router, MDX blogging, a custom music sho
 
 - `/` - Home
 - `/about` - About, skills, experience, and GitHub contribution calendar
+- `/resume` - Print-ready resume with full CV content (summary, skills, experience, education)
 - `/blog` - Blog index from MDX content
 - `/blog/[slug]` - Individual blog post pages
 - `/feed.xml` - RSS feed of all published blog posts
@@ -49,6 +50,11 @@ Modern portfolio built with Next.js App Router, MDX blogging, a custom music sho
   - S3/CloudFront signed URLs (server-side signing only)
   - playback state persisted across page loads (track, volume)
   - keyboard shortcuts: Space (play/pause), M (mute), ←/→ (prev/next), ↑/↓ (volume)
+- Resume page (`/resume`) with:
+  - structured single-column layout matching site dark/green theme
+  - bullet-point experience sourced from CV YAML (`data.ts`)
+  - `@media print` styles: hides nav/controls, forces readable colors, avoids page breaks inside atomic blocks
+  - Print button + Download Resume PDF action
 - Contact page with:
   - validated form submission
   - email API route (`/api/sendMail`)

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -13,7 +13,7 @@ const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: 'About | Akshay Gupta',
+  title: 'About',
   description:
     'Learn about my journey as a Senior Staff Engineer at PeopleGrove, my skills, experience, and what drives me in web development.',
   openGraph: {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -179,7 +179,7 @@ export async function generateMetadata({
 
     if (!post) {
       return {
-        title: 'Post Not Found | Akshay Gupta',
+        title: 'Post Not Found',
         description: `The blog post you're looking for does not exist`,
         metadataBase: new URL(siteUrl),
       };
@@ -189,7 +189,7 @@ export async function generateMetadata({
     const description = metadata.excerpt || metadata.title;
 
     return {
-      title: `${metadata.title} | Akshay Gupta's Blog`,
+      title: metadata.title,
       description,
       metadataBase: new URL(siteUrl),
       openGraph: {
@@ -216,7 +216,7 @@ export async function generateMetadata({
   } catch (error) {
     logger.error('Error generating metadata:', error);
     return {
-      title: 'Error | Akshay Gupta',
+      title: 'Error',
       description: 'An error occurred while loading this blog post',
       metadataBase: new URL(siteUrl),
     };

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -10,7 +10,7 @@ const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: 'Blog | Akshay Gupta',
+  title: 'Blog',
   description:
     'Read my latest thoughts and insights about web development, technology, and software engineering.',
   openGraph: {

--- a/src/app/components/Layout/Header.tsx
+++ b/src/app/components/Layout/Header.tsx
@@ -7,6 +7,7 @@ import { Fragment, useEffect, useMemo, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   faBlog,
+  faFileLines,
   faHouse,
   faIdBadge,
   faMapLocation,
@@ -30,6 +31,7 @@ const Header = () => {
 
   const activeSection = useMemo(() => {
     if (pathname === '/about') return 'about';
+    if (pathname === '/resume') return 'resume';
     if (pathname === '/contact') return 'contact';
     if (pathname === '/blog' || pathname.startsWith('/blog/')) return 'blog';
     if (pathname === '/music') return 'music';
@@ -150,6 +152,20 @@ const Header = () => {
                   width={20}
                 />
                 <span>About Me</span>
+              </Link>
+            </li>
+            <li className={activeSection === 'resume' ? 'active' : ''}>
+              <Link
+                className='nav-link'
+                href='/resume'
+                onClick={() => setSideBarToggle(false)}
+              >
+                <FontAwesomeIcon
+                  icon={faFileLines as IconProp}
+                  height={20}
+                  width={20}
+                />
+                <span>Resume</span>
               </Link>
             </li>
             <li className={activeSection === 'blog' ? 'active' : ''}>

--- a/src/app/contact/layout.tsx
+++ b/src/app/contact/layout.tsx
@@ -5,7 +5,7 @@ const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: 'Contact | Akshay Gupta',
+  title: 'Contact',
   description:
     'Get in touch with me for collaboration opportunities, project discussions, or any questions you might have.',
   openGraph: {

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -9,7 +9,7 @@ const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: 'My Music | Akshay Gupta',
+  title: 'My Music',
   description:
     'Listen to my latest remixes and music productions. Enjoy the beats!',
   openGraph: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import Layout from '@/app/components/Layout';
 import { getSiteUrl } from '@/lib/site-url';
 
@@ -81,7 +82,18 @@ export default function Home() {
                     that performs well, feels intuitive, and creates measurable
                     business impact.
                   </p>
-                  <div className={styles.btnBar}>
+                  <div
+                    className={styles.btnBar}
+                    style={{
+                      display: 'flex',
+                      gap: '12px',
+                      flexWrap: 'wrap',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <Link className='px-btn px-btn-regular' href='/resume'>
+                      View Resume
+                    </Link>
                     <a
                       className='px-btn px-btn-regular'
                       href='/assets/Akshay_Gupta_CV.pdf'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -99,7 +99,7 @@ export default function Home() {
                       href='/assets/Akshay_Gupta_CV.pdf'
                       download
                     >
-                      Download CV
+                      Download Resume
                     </a>
                   </div>
                 </div>

--- a/src/app/resume/ResumeActions.tsx
+++ b/src/app/resume/ResumeActions.tsx
@@ -20,7 +20,7 @@ export default function ResumeActions() {
         className='px-btn px-btn-regular'
         href='/assets/Akshay_Gupta_CV.pdf'
         download
-        aria-label='Download CV as PDF'
+        aria-label='Download resume as PDF'
       >
         <FontAwesomeIcon icon={faFileArrowDown as IconProp} />
         <span>Download PDF</span>

--- a/src/app/resume/ResumeActions.tsx
+++ b/src/app/resume/ResumeActions.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPrint, faFileArrowDown } from '@fortawesome/free-solid-svg-icons';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import styles from '@/app/styles/sections/resumeSection.module.scss';
+
+export default function ResumeActions() {
+  return (
+    <div className={styles.resumeActions}>
+      <button
+        className='px-btn px-btn-regular'
+        onClick={() => window.print()}
+        aria-label='Print resume'
+      >
+        <FontAwesomeIcon icon={faPrint as IconProp} />
+        <span>Print</span>
+      </button>
+      <a
+        className='px-btn px-btn-regular'
+        href='/assets/Akshay_Gupta_CV.pdf'
+        download
+        aria-label='Download CV as PDF'
+      >
+        <FontAwesomeIcon icon={faFileArrowDown as IconProp} />
+        <span>Download PDF</span>
+      </a>
+    </div>
+  );
+}

--- a/src/app/resume/data.ts
+++ b/src/app/resume/data.ts
@@ -1,0 +1,144 @@
+export interface ResumeSkillCategory {
+  label: string;
+  details: string;
+}
+
+export interface ResumeRole {
+  position: string;
+  startDate: string;
+  endDate: string;
+  bullets: string[];
+}
+
+export interface ResumeCompany {
+  company: string;
+  location: string;
+  summary?: string;
+  roles: ResumeRole[];
+}
+
+export interface ResumeEducation {
+  institution: string;
+  degree: string;
+  area: string;
+  location: string;
+  date: string;
+}
+
+export interface ResumeData {
+  name: string;
+  headline: string;
+  location: string;
+  email: string;
+  website: string;
+  summary: string;
+  skills: ResumeSkillCategory[];
+  experience: ResumeCompany[];
+  education: ResumeEducation[];
+}
+
+export const resumeData: ResumeData = {
+  name: 'Akshay Gupta',
+  headline: 'Senior Staff Engineer',
+  location: 'Mumbai, India',
+  email: 'akshaygupta.live@gmail.com',
+  website: 'https://akshaygupta.live',
+  summary:
+    'Senior Staff Engineer with 8+ years building scalable backend, platform, and AI-enabled systems on GCP and AWS. Expert in PostgreSQL performance tuning, distributed messaging, zero-downtime migrations, and cloud cost optimization, with a track record of owning platform-level architecture and leading engineering delivery across high-growth SaaS products.',
+  skills: [
+    { label: 'Languages', details: 'TypeScript, JavaScript, Python, Go' },
+    { label: 'Backend', details: 'Node.js, Express.js, Sails.js, REST APIs' },
+    {
+      label: 'AI & Tooling',
+      details: 'Model Context Protocol (MCP), RAG, vector & semantic search',
+    },
+    { label: 'Frontend', details: 'React, Next.js, Redux, React-Query' },
+    {
+      label: 'Databases',
+      details: 'PostgreSQL, Redis, Elasticsearch, BigQuery, Firestore',
+    },
+    {
+      label: 'Cloud',
+      details:
+        'GCP (CloudSQL, Pub/Sub, Functions, Cloud Storage), AWS (RDS, Lambda, S3, SQS, CloudFront)',
+    },
+    { label: 'Messaging', details: 'RabbitMQ, Google Pub/Sub, AWS SQS' },
+    { label: 'DevOps', details: 'Docker, ArgoCD, GitHub Actions' },
+    { label: 'Observability', details: 'Sentry, NewRelic, Kibana' },
+    { label: 'Testing', details: 'Jest, Mocha, React Testing Library' },
+  ],
+  experience: [
+    {
+      company: 'PeopleGrove',
+      location: 'Remote, India',
+      summary:
+        'Career and mentorship SaaS platform serving 200+ university clients and 1M+ users.',
+      roles: [
+        {
+          position: 'Senior Staff Engineer',
+          startDate: '2024-01',
+          endDate: 'present',
+          bullets: [
+            'Architected and delivered a RAG-based support chatbot, designing the document ingestion and embedding pipeline, vector retrieval layer, and response-grounding flow over internal docs and ticket history, automating resolution of recurring client issues and reducing manual support load.',
+            'Re-architected logging standards across services by eliminating redundant log levels and standardizing structured logging, cutting Google Cloud Logging costs by 40%.',
+            'Led the zero-downtime migration of the Student Opportunity Center from Firestore to PostgreSQL, owning rollout strategy and preserving continuity across customer-facing workflows.',
+            'Drove a cross-service technical-debt reduction initiative, refactoring core modules and tightening test coverage to reduce reported production issues by 25%.',
+            'Built a Go MCP server connecting AI coding assistants directly to PostgreSQL for live EXPLAIN analysis, index simulation, and automated health audits; shipped as a dependency-free 15 MB static binary.',
+            'Architected a hybrid (BM25 + vector) code-search MCP server over a multi-repo workspace, designing the indexing pipeline, symbol-graph resolution layer, and unified query interface so AI agents trace features and navigate cross-repo code in one tool call, accelerating navigation and engineer onboarding.',
+          ],
+        },
+        {
+          position: 'Engineering Manager',
+          startDate: '2022-04',
+          endDate: '2023-12',
+          bullets: [
+            'Mentored 3 engineers through code reviews, architecture guidance, and delivery planning, reducing development cycle time by 15%.',
+            'Architected and launched an NLP-powered messaging system that lifted user engagement by 20% and customer satisfaction by 10%.',
+            'Built a real-time sync pipeline between BigQuery and Customer.io, increasing marketing campaign effectiveness by 15% through more personalized targeting.',
+            'Created a migration tool that transitioned 200+ university customer sites to PeopleGrove V2, reducing manual setup effort while preserving customer continuity.',
+          ],
+        },
+        {
+          position: 'SDE I — Senior SDE',
+          startDate: '2019-03',
+          endDate: '2022-03',
+          bullets: [
+            'Optimized legacy REST APIs through PostgreSQL query tuning, Redis caching, and RabbitMQ-based async processing, cutting response times from ~20 seconds to under 50 milliseconds.',
+            'Built a high-volume newsletter service on Google Pub/Sub and SendGrid, delivering personalized content to over 1 million users monthly.',
+            'Migrated the legacy Angular.js frontend to React, improving page load times by 25% and modernizing the platform\'s UI architecture.',
+            'Implemented React code-splitting to raise the Lighthouse performance score above 90, improving load times and retention.',
+            'Built a weighted-factor bulk matching tool for mentor-mentee pairings, increasing platform engagement and contributing to 15% revenue growth.',
+            'Developed a feature-flag management system enabling agile rollouts and reducing rollback incidents by 90%.',
+            'Improved backend reliability via worker-thread processing for CPU-intensive tasks, automated Cron workflows, and Postmark-based transactional email.',
+          ],
+        },
+      ],
+    },
+    {
+      company: 'Tata Consultancy Services',
+      location: 'Hyderabad, India',
+      summary: 'Client: ARM Semiconductors · Project: Deal Evaluator & Fusion',
+      roles: [
+        {
+          position: 'Assistant System Engineer',
+          startDate: '2017-09',
+          endDate: '2019-03',
+          bullets: [
+            'Built a React application consuming SAP OData services to deliver sales insights for ARM Semiconductors stakeholders, earning recognition from client leadership.',
+            'Consolidated Tableau, Power BI, and SAP BusinessObjects reporting into a single React interface, giving business teams unified access to BI dashboards.',
+            'Led 10+ React.js workshops for the internal team, building frontend capability across the practice.',
+          ],
+        },
+      ],
+    },
+  ],
+  education: [
+    {
+      institution: 'Rajiv Gandhi Proudyogiki Vishwavidyalaya',
+      degree: 'BE',
+      area: 'Computer Science',
+      location: 'Indore, India',
+      date: '2013 – 2017',
+    },
+  ],
+};

--- a/src/app/resume/error.tsx
+++ b/src/app/resume/error.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from '@/app/components/RouteError';

--- a/src/app/resume/loading.tsx
+++ b/src/app/resume/loading.tsx
@@ -1,0 +1,5 @@
+import LoadingIndicator from '@/app/components/LoadingIndicator';
+
+export default function ResumeLoading() {
+  return <LoadingIndicator />;
+}

--- a/src/app/resume/opengraph-image.tsx
+++ b/src/app/resume/opengraph-image.tsx
@@ -1,0 +1,78 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'Resume — Akshay Gupta, Senior Staff Engineer';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+export const contentType = 'image/png';
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          fontSize: 48,
+          background: 'linear-gradient(135deg, #000000, #1a1a1a, #2a2a2a)',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+          padding: '60px 80px',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 72,
+            fontWeight: 'bold',
+            marginBottom: 24,
+            background: 'linear-gradient(90deg, #2fbf71, #00d4aa)',
+            backgroundClip: 'text',
+            WebkitBackgroundClip: 'text',
+            color: 'transparent',
+            textAlign: 'center',
+          }}
+        >
+          Resume
+        </div>
+        <div
+          style={{
+            fontSize: 36,
+            textAlign: 'center',
+            color: '#e0e0e0',
+            marginBottom: 16,
+            lineHeight: 1.2,
+          }}
+        >
+          Akshay Gupta
+        </div>
+        <div
+          style={{
+            fontSize: 24,
+            textAlign: 'center',
+            color: '#aaaaaa',
+            marginBottom: 40,
+          }}
+        >
+          Senior Staff Engineer · 8+ Years Experience
+        </div>
+        <div
+          style={{
+            fontSize: 20,
+            color: '#2fbf71',
+            fontWeight: 500,
+          }}
+        >
+          akshaygupta.live/resume
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+    }
+  );
+}

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,0 +1,193 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Layout from '@/app/components/Layout';
+import ResumeActions from './ResumeActions';
+import { resumeData } from './data';
+import { getSiteUrl } from '@/lib/site-url';
+
+import styles from '@/app/styles/sections/resumeSection.module.scss';
+
+const siteUrl = getSiteUrl();
+
+export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
+  title: 'Resume | Akshay Gupta',
+  description:
+    'Resume of Akshay Gupta — Senior Staff Engineer with 8+ years building scalable backend, platform, and AI-enabled systems on GCP and AWS.',
+  openGraph: {
+    type: 'profile',
+    title: 'Resume | Akshay Gupta',
+    description:
+      'Resume of Akshay Gupta — Senior Staff Engineer with 8+ years building scalable backend, platform, and AI-enabled systems on GCP and AWS.',
+    url: `${siteUrl}/resume`,
+    siteName: 'Akshay Gupta',
+    locale: 'en_US',
+    images: [
+      {
+        url: '/resume/opengraph-image',
+        width: 1200,
+        height: 630,
+        alt: 'Resume — Akshay Gupta, Senior Staff Engineer',
+        type: 'image/png',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Resume | Akshay Gupta',
+    description:
+      'Resume of Akshay Gupta — Senior Staff Engineer with 8+ years building scalable backend, platform, and AI-enabled systems on GCP and AWS.',
+    creator: '@ashay_music',
+    images: ['/resume/opengraph-image'],
+  },
+  alternates: {
+    canonical: `${siteUrl}/resume`,
+  },
+};
+
+function formatYearMonth(ym: string): string {
+  const [year, month] = ym.split('-');
+  return new Date(Number(year), Number(month) - 1, 1).toLocaleString('en-US', {
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+export default function Resume() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: resumeData.name,
+    jobTitle: resumeData.headline,
+    url: siteUrl,
+    email: resumeData.email,
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: 'Mumbai',
+      addressCountry: 'IN',
+    },
+    worksFor: {
+      '@type': 'Organization',
+      name: 'PeopleGrove',
+      url: 'https://www.peoplegrove.com',
+    },
+    sameAs: [
+      'https://github.com/gupta-akshay',
+      'https://linkedin.com/in/akshayguptaujn',
+      'https://twitter.com/ashay_music',
+    ],
+    description: resumeData.summary,
+    alumniOf: {
+      '@type': 'EducationalOrganization',
+      name: 'Rajiv Gandhi Proudyogiki Vishwavidyalaya',
+    },
+  };
+
+  return (
+    <Layout>
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <section
+        id='resume'
+        data-nav-tooltip='Resume'
+        className='pp-section pp-scrollable section'
+        style={{ position: 'relative', minHeight: '100vh', overflowX: 'hidden' }}
+      >
+        <div className='container' style={{ position: 'relative', zIndex: 10 }}>
+          {/* Page title + action buttons */}
+          <div className={styles.resumePageHeader}>
+            <div className='title'>
+              <h3>Resume</h3>
+            </div>
+            <ResumeActions />
+          </div>
+
+          {/* Contact header */}
+          <div className={`${styles.resumeContactHeader} route-shell`}>
+            <h1 className={styles.resumeName}>{resumeData.name}</h1>
+            <p className={styles.resumeHeadline}>{resumeData.headline}</p>
+            <div className={styles.resumeContact}>
+              <span>{resumeData.location}</span>
+              <a href={`mailto:${resumeData.email}`}>{resumeData.email}</a>
+              <Link href='/'>{resumeData.website.replace('https://', '')}</Link>
+            </div>
+          </div>
+
+          {/* Summary */}
+          <div className={styles.resumeSection}>
+            <h2 className={styles.resumeSectionTitle}>Summary</h2>
+            <p className={styles.resumeSummaryText}>{resumeData.summary}</p>
+          </div>
+
+          {/* Skills */}
+          <div className={styles.resumeSection}>
+            <h2 className={styles.resumeSectionTitle}>Skills</h2>
+            <dl className={styles.skillsGrid}>
+              {resumeData.skills.map((skill) => (
+                <div key={skill.label} className={styles.skillRow}>
+                  <dt className={styles.skillLabel}>{skill.label}</dt>
+                  <dd className={styles.skillDetails}>{skill.details}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          {/* Experience */}
+          <div className={styles.resumeSection}>
+            <h2 className={styles.resumeSectionTitle}>Experience</h2>
+            {resumeData.experience.map((company) => (
+              <div key={company.company} className={styles.companyBlock}>
+                <div className={styles.companyHeaderRow}>
+                  <h3 className={styles.companyName}>{company.company}</h3>
+                  <span className={styles.companyLocation}>
+                    {company.location}
+                  </span>
+                </div>
+                {company.summary && (
+                  <p className={styles.companySummary}>{company.summary}</p>
+                )}
+                {company.roles.map((role) => (
+                  <div key={role.position} className={styles.roleBlock}>
+                    <div className={styles.roleHeaderRow}>
+                      <h4 className={styles.roleTitle}>{role.position}</h4>
+                      <span className={styles.roleDates}>
+                        {formatYearMonth(role.startDate)} –{' '}
+                        {role.endDate === 'present'
+                          ? 'Present'
+                          : formatYearMonth(role.endDate)}
+                      </span>
+                    </div>
+                    <ul className={styles.bulletList}>
+                      {role.bullets.map((bullet, i) => (
+                        <li key={i}>{bullet}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+
+          {/* Education */}
+          <div className={styles.resumeSection}>
+            <h2 className={styles.resumeSectionTitle}>Education</h2>
+            {resumeData.education.map((edu) => (
+              <div key={edu.institution} className={styles.eduBlock}>
+                <div className={styles.eduHeaderRow}>
+                  <h3 className={styles.eduInstitution}>{edu.institution}</h3>
+                  <span className={styles.eduDate}>{edu.date}</span>
+                </div>
+                <p className={styles.eduDegree}>
+                  {edu.degree} in {edu.area}
+                </p>
+                <p className={styles.eduLocation}>{edu.location}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -11,7 +11,7 @@ const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
-  title: 'Resume | Akshay Gupta',
+  title: 'Resume',
   description:
     'Resume of Akshay Gupta — Senior Staff Engineer with 8+ years building scalable backend, platform, and AI-enabled systems on GCP and AWS.',
   openGraph: {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -34,6 +34,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
+      url: `${baseUrl}/resume`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
+    {
       url: `${baseUrl}/blog`,
       lastModified: new Date(),
       changeFrequency: 'weekly',

--- a/src/app/styles/sections/resumeSection.module.scss
+++ b/src/app/styles/sections/resumeSection.module.scss
@@ -1,0 +1,440 @@
+@use 'sass:color';
+@use '../variables' as *;
+@use '../mixin' as *;
+
+// Light theme overrides
+:global(body.theme-light) {
+  .resumeSectionTitle {
+    color: $px-dark;
+  }
+
+  .resumeName {
+    color: $px-dark;
+  }
+
+  .resumeHeadline {
+    color: $px-theme;
+  }
+
+  .resumeContact {
+    a,
+    span {
+      color: $px-body-light;
+    }
+  }
+
+  .resumeSummaryText {
+    color: $px-body-light;
+  }
+
+  .skillDetails {
+    color: $px-body-light;
+  }
+
+  .companyBlock {
+    border-bottom-color: rgba($px-dark, 0.08);
+  }
+
+  .companyName {
+    color: $px-dark;
+  }
+
+  .companyLocation {
+    color: rgba($px-dark, 0.5);
+  }
+
+  .companySummary {
+    color: rgba($px-dark, 0.55);
+  }
+
+  .roleTitle {
+    color: $px-dark;
+  }
+
+  .bulletList li {
+    color: $px-body-light;
+  }
+
+  .eduInstitution {
+    color: $px-dark;
+  }
+
+  .eduDegree {
+    color: $px-body-light;
+  }
+
+  .eduLocation {
+    color: rgba($px-dark, 0.5);
+  }
+}
+
+// Page header row: title + action buttons
+.resumePageHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 32px;
+  flex-wrap: wrap;
+  gap: 16px;
+
+  @include down-sm {
+    flex-direction: column;
+  }
+}
+
+.resumeActions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding-top: 8px;
+}
+
+// Contact header card
+.resumeContactHeader {
+  margin-bottom: 40px;
+}
+
+.resumeName {
+  color: $px-white;
+  font-size: 2.2rem;
+  font-weight: 700;
+  margin: 0 0 4px;
+  letter-spacing: -0.02em;
+
+  @include down-sm {
+    font-size: 1.8rem;
+  }
+}
+
+.resumeHeadline {
+  color: $px-theme;
+  font-size: 1.1rem;
+  font-weight: 500;
+  margin: 0 0 14px;
+}
+
+.resumeContact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 20px;
+  font-size: 0.9rem;
+
+  a {
+    color: $px-body;
+    text-decoration: none;
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: $px-theme;
+    }
+  }
+
+  span {
+    color: $px-body;
+  }
+}
+
+// Section block
+.resumeSection {
+  margin-bottom: 44px;
+}
+
+.resumeSectionTitle {
+  color: $px-white;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  padding-bottom: 10px;
+  margin: 0 0 24px;
+  border-bottom: 2px solid $px-theme;
+}
+
+// Summary
+.resumeSummaryText {
+  color: $px-body;
+  line-height: 1.75;
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+// Skills: definition list as two-column grid
+.skillsGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
+  margin: 0;
+
+  @include up-sm {
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 32px;
+  }
+}
+
+.skillRow {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  line-height: 1.5;
+}
+
+.skillLabel {
+  color: $px-theme;
+  font-weight: 600;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  min-width: 100px;
+  flex-shrink: 0;
+
+  &::after {
+    content: ':';
+  }
+}
+
+.skillDetails {
+  color: $px-body;
+  font-size: 0.88rem;
+}
+
+// Experience
+.companyBlock {
+  margin-bottom: 32px;
+  padding-bottom: 32px;
+  border-bottom: 1px solid rgba($px-white, 0.06);
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+}
+
+.companyHeaderRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.companyName {
+  color: $px-white;
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.companyLocation {
+  color: rgba($px-white, 0.45);
+  font-size: 0.85rem;
+}
+
+.companySummary {
+  color: rgba($px-white, 0.5);
+  font-size: 0.85rem;
+  font-style: italic;
+  margin: 4px 0 8px;
+}
+
+.roleBlock {
+  padding: 14px 0 14px 18px;
+  border-left: 2px solid rgba($px-theme, 0.35);
+  margin: 14px 0 0;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.roleHeaderRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.roleTitle {
+  color: $px-white;
+  font-size: 0.97rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.roleDates {
+  color: $px-theme;
+  font-size: 0.82rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.bulletList {
+  margin: 0;
+  padding-left: 1.3rem;
+  list-style: disc outside;
+
+  li {
+    color: $px-body;
+    font-size: 0.9rem;
+    line-height: 1.68;
+    margin-bottom: 7px;
+
+    &::marker {
+      color: $px-theme;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+// Education
+.eduBlock {
+  margin-bottom: 20px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.eduHeaderRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.eduInstitution {
+  color: $px-white;
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.eduDate {
+  color: $px-theme;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.eduDegree {
+  color: $px-body;
+  font-size: 0.9rem;
+  margin: 2px 0;
+}
+
+.eduLocation {
+  color: rgba($px-white, 0.45);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+// ============================================================
+// PRINT STYLES
+// ============================================================
+@media print {
+  :global(.header-left),
+  :global(.mob-header),
+  :global(.fixed-controls),
+  :global(.sidebar-overlay) {
+    display: none !important;
+  }
+
+  :global(.main-right) {
+    left: 0 !important;
+    width: 100% !important;
+    position: static !important;
+    height: auto !important;
+  }
+
+  :global(.pp-section) {
+    background: #fff !important;
+    min-height: unset !important;
+    overflow: visible !important;
+  }
+
+  :global(.pp-scrollable) {
+    overflow: visible !important;
+  }
+
+  :global(.route-shell) {
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    margin-bottom: 12px !important;
+  }
+
+  .resumeActions {
+    display: none !important;
+  }
+
+  .resumePageHeader {
+    margin-bottom: 16px;
+  }
+
+  .resumeName,
+  .companyName,
+  .roleTitle,
+  .eduInstitution {
+    color: #000 !important;
+  }
+
+  .resumeHeadline,
+  .skillLabel,
+  .roleDates,
+  .eduDate {
+    color: #1a7a45 !important;
+  }
+
+  .resumeSummaryText,
+  .skillDetails,
+  .companyLocation,
+  .companySummary,
+  .bulletList li,
+  .eduDegree,
+  .eduLocation {
+    color: #333 !important;
+  }
+
+  .resumeContact {
+    a,
+    span {
+      color: #333 !important;
+    }
+  }
+
+  .resumeSectionTitle {
+    color: #000 !important;
+    border-bottom-color: #1a7a45 !important;
+  }
+
+  .companyBlock {
+    border-bottom-color: #ddd !important;
+  }
+
+  .roleBlock {
+    border-left-color: #1a7a45 !important;
+  }
+
+  .bulletList li::marker {
+    color: #1a7a45 !important;
+  }
+
+  .companyBlock,
+  .roleBlock,
+  .eduBlock,
+  .resumeSection {
+    page-break-inside: avoid;
+  }
+
+  .resumeSectionTitle {
+    page-break-after: avoid;
+  }
+}

--- a/src/app/styles/sections/resumeSection.module.scss
+++ b/src/app/styles/sections/resumeSection.module.scss
@@ -429,8 +429,7 @@
 
   .companyBlock,
   .roleBlock,
-  .eduBlock,
-  .resumeSection {
+  .eduBlock {
     page-break-inside: avoid;
   }
 


### PR DESCRIPTION
## Summary

- Adds `/resume` route — structured, single-column CV page using the site's dark/green theme with full dark/light mode support
- Experience rendered as company blocks with nested role cards and bullet points (sourced from CV YAML), replacing the prose format used on `/about`
- Print styles (`@media print`) hide the nav sidebar, force white background and black text, and suppress action buttons for clean browser printing
- Print + Download PDF action buttons at top of page (`ResumeActions` client leaf keeps `page.tsx` a Server Component)
- OG image, canonical metadata, and `Person` JSON-LD structured data
- Sidebar nav updated: Resume entry added between About and Blogs with `faFileLines` icon
- Homepage updated: "View Resume" link added alongside existing "Download CV" button
- `/resume` added to sitemap (priority 0.7, monthly)

## Test plan

- [x] Open `/resume` — verify Summary, Skills, Experience (PeopleGrove + TCS), Education all render
- [x] Toggle day/night — verify light and dark themes apply correctly
- [x] Click Print — verify browser print dialog shows clean layout (no nav, white bg, readable text)
- [x] Click Download PDF — verify PDF download triggers
- [x] Check sidebar nav — Resume appears between About and Blogs with document icon, highlights on `/resume`
- [x] Check homepage — View Resume + Download CV buttons side by side
- [x] Check `/sitemap.xml` — `/resume` entry present between `/about` and `/blog`