### PR TITLE
fix: correct icon inline layout and remove print button

### DIFF
--- a/src/app/components/Icon/Icon.tsx
+++ b/src/app/components/Icon/Icon.tsx
@@ -28,7 +28,10 @@ const Icon = ({
   const icon = icons[name];
 
   const svgHeight: number | string = height ?? (size ? `${parseFloat(size)}em` : '1em');
-  const svgWidth: number | string = width ?? 'auto';
+  // Omit width when not explicitly set — the browser derives it from the
+  // viewBox aspect ratio. Passing width="auto" as an SVG attribute is treated
+  // as 100% by many browsers (SVG 1.1 default), which breaks inline layout.
+  const svgWidth: number | undefined = width;
 
   const classNames = [styles.icon, spin ? styles.spin : undefined, className]
     .filter(Boolean)

--- a/src/app/resume/ResumeActions.tsx
+++ b/src/app/resume/ResumeActions.tsx
@@ -1,19 +1,9 @@
-'use client';
-
 import Icon from '@/app/components/Icon/Icon';
 import styles from '@/app/styles/sections/resumeSection.module.scss';
 
 export default function ResumeActions() {
   return (
     <div className={styles.resumeActions}>
-      <button
-        className='px-btn px-btn-regular'
-        onClick={() => window.print()}
-        aria-label='Print resume'
-      >
-        <Icon name='print' />
-        <span>Print</span>
-      </button>
       <a
         className='px-btn px-btn-regular'
         href='/assets/Akshay_Gupta_CV.pdf'

--- a/src/app/styles/sections/resumeSection.module.scss
+++ b/src/app/styles/sections/resumeSection.module.scss
@@ -88,6 +88,13 @@
   align-items: center;
   flex-wrap: wrap;
   padding-top: 8px;
+
+  a,
+  button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
 }
 
 // Contact header card


### PR DESCRIPTION
SVG width="auto" was being treated as 100% by browsers (SVG 1.1 default), making each icon fill the full container width and pushing the adjacent text onto the next line. Fix by omitting the width attribute when not explicitly provided — the browser then derives it from the viewBox aspect ratio.

Also removes the Print button from ResumeActions; the download link now renders as a server component (drops the 'use client' directive).