### PR TITLE
chore(deps): update resend and import-in-the-middle

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "request-ip": "^3.3.0",
-    "resend": "^6.16.0",
+    "resend": "^6.17.0",
     "sanitize-html": "^2.17.5",
     "zod": "^4.4.3"
   },
@@ -56,7 +56,7 @@
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.10",
     "eslint-config-prettier": "^10.1.8",
-    "import-in-the-middle": "^3.2.0",
+    "import-in-the-middle": "^3.3.0",
     "prettier": "^3.9.4",
     "require-in-the-middle": "^8.0.1",
     "sass": "^1.101.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       resend:
-        specifier: ^6.16.0
-        version: 6.16.0(@react-email/render@1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
+        specifier: ^6.17.0
+        version: 6.17.0(@react-email/render@1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
       sanitize-html:
         specifier: ^2.17.5
         version: 2.17.5
@@ -137,8 +137,8 @@ importers:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       import-in-the-middle:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^3.3.0
+        version: 3.3.0
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
@@ -2043,11 +2043,6 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
-  acorn-import-attributes@1.9.5:
-    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
-    peerDependencies:
-      acorn: ^8
-
   acorn-import-phases@1.0.4:
     resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
     engines: {node: '>=10.13.0'}
@@ -3178,8 +3173,8 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  import-in-the-middle@3.2.0:
-    resolution: {integrity: sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ==}
+  import-in-the-middle@3.3.0:
+    resolution: {integrity: sha512-v4+k+PLt4z6g2ydEcXhfinTJxfgKJDWOW0v0GZNA5n2qToHFObpH4nGLhJdwnXnX4T14oREx/M62dS9GkpmSbQ==}
     engines: {node: '>=18'}
 
   import-meta-resolve@4.2.0:
@@ -4050,8 +4045,8 @@ packages:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
-  resend@6.16.0:
-    resolution: {integrity: sha512-SaKISwHtxvAxneF84Njgnzg+zdngUu1vOT/paRU1De9QF+zXQR3GnwJHSh+mpJPjUhsGD4WxYi5CfKkXMkDqwg==}
+  resend@6.17.0:
+    resolution: {integrity: sha512-hYNLU58nKg1Sx9kPF1E6fo447/9OMNbk3pOzuQGZMtoRU4FhtNTrW7SHFLPT8F8quTcIAa6Cs5Q5hEuWHJNTpA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@react-email/render': '*'
@@ -5481,7 +5476,7 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.214.0
-      import-in-the-middle: 3.2.0
+      import-in-the-middle: 3.3.0
       require-in-the-middle: 8.0.1
     transitivePeerDependencies:
       - supports-color
@@ -5793,7 +5788,7 @@ snapshots:
       '@sentry/conventions': 0.12.0
       '@sentry/core': 10.63.0
       '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
-      import-in-the-middle: 3.2.0
+      import-in-the-middle: 3.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
@@ -5811,7 +5806,7 @@ snapshots:
       '@sentry/node-core': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       '@sentry/opentelemetry': 10.63.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))
       '@sentry/server-utils': 10.63.0
-      import-in-the-middle: 3.2.0
+      import-in-the-middle: 3.3.0
     transitivePeerDependencies:
       - '@opentelemetry/core'
       - '@opentelemetry/exporter-trace-otlp-http'
@@ -6459,10 +6454,6 @@ snapshots:
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
-
-  acorn-import-attributes@1.9.5(acorn@8.17.0):
-    dependencies:
-      acorn: 8.17.0
 
   acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
@@ -7794,11 +7785,10 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  import-in-the-middle@3.2.0:
+  import-in-the-middle@3.3.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-import-attributes: 1.9.5(acorn@8.17.0)
       cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.0
       module-details-from-path: 1.0.4
 
   import-meta-resolve@4.2.0: {}
@@ -9020,7 +9010,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  resend@6.16.0(@react-email/render@1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
+  resend@6.17.0(@react-email/render@1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)):
     dependencies:
       postal-mime: 2.7.4
       standardwebhooks: 1.0.0


### PR DESCRIPTION
## Summary

Dependency audit of the repository. `pnpm audit` reports **no known vulnerabilities**, and nearly every package already tracks the latest version within its existing semver range. This PR applies the two safe updates that had newer releases available and documents why a third (ESLint 10) was held back.

## Updates applied

| Package | From | To | Type | Notes |
|---|---|---|---|---|
| `resend` | 6.16.0 | 6.17.0 | minor | Backwards-compatible; used by the contact form (`src/app/api/sendMail`). |
| `import-in-the-middle` | 3.2.0 | 3.3.0 | minor | Backwards-compatible; Sentry/OpenTelemetry instrumentation dependency. |

No source code changes were required — both are drop-in minor bumps.

## Held back

| Package | From | Latest | Reason |
|---|---|---|---|
| `eslint` | 9.39.4 | 10.6.0 | **Major, incompatible.** `eslint-config-next@16.2.10` bundles `eslint-plugin-react@7.37.5`, which calls `context.getFilename()` — an API removed in ESLint 10. Running lint under ESLint 10 crashes with `TypeError: contextOrFilename.getFilename is not a function`. Will revisit once the Next.js ESLint plugin stack supports ESLint 10. |

## Security

- `pnpm audit`: **0 vulnerabilities** — no CVEs or advisories against current or updated dependencies.
- All other dependencies are already at their latest within-range versions.

## Verification

- ✅ `pnpm install` — clean
- ✅ `pnpm lint` — passes (ESLint 9)
- ✅ `pnpm build` — production build compiles, type-checks, and prerenders all routes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkoMUDgJqpZ5FfX5XkZxmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DkoMUDgJqpZ5FfX5XkZxmJ)_