### PR TITLE
Keep active blog TOC entries in view

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "devicon": "^2.17.0",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
+    "github-slugger": "^2.0.0",
+    "mdast-util-to-string": "^4.0.0",
     "mermaid": "^11.16.0",
     "next": "^16.2.10",
     "react": "^19.2.7",
@@ -39,9 +41,13 @@
     "rehype-prism-plus": "^2.0.2",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "remark-mdx": "^3.1.1",
+    "remark-parse": "^11.0.0",
     "request-ip": "^3.3.0",
     "resend": "^6.17.2",
     "sanitize-html": "^2.17.6",
+    "unified": "^11.0.5",
+    "unist-util-visit": "^5.1.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,12 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
@@ -90,6 +96,12 @@ importers:
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
+      remark-mdx:
+        specifier: ^3.1.1
+        version: 3.1.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
       request-ip:
         specifier: ^3.3.0
         version: 3.3.0
@@ -99,6 +111,12 @@ importers:
       sanitize-html:
         specifier: ^2.17.6
         version: 2.17.6
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/src/app/blog/[slug]/TableOfContentsMDX.tsx
+++ b/src/app/blog/[slug]/TableOfContentsMDX.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { TOCHeading } from '@/lib/mdx/types';
 
 import '../../../app/components/TableOfContents/TableOfContents.scss';
@@ -95,14 +95,17 @@ const TableOfContentsMDX: React.FC<TableOfContentsMDXProps> = ({
   const [activeId, setActiveId] = useState<string>('');
   const [isVisible, setIsVisible] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
+  const tocNavRef = useRef<HTMLElement>(null);
 
   const nestedHeadings = buildNestedTOC(headings);
 
   const setupObserver = useCallback(() => {
     if (headings.length < minHeadings) return null;
 
-    const headingElements = headings.map((h) => document.getElementById(h.id));
-    if (headingElements.some((el) => el === null)) return null;
+    const headingElements = headings
+      .map((heading) => document.getElementById(heading.id))
+      .filter((element): element is HTMLElement => element !== null);
+    if (headingElements.length === 0) return null;
 
     const observer = new IntersectionObserver(
       (entries) => {
@@ -140,6 +143,37 @@ const TableOfContentsMDX: React.FC<TableOfContentsMDXProps> = ({
   }, [setupObserver, headings, minHeadings]);
 
   useEffect(() => {
+    if (!activeId) return;
+
+    const nav = tocNavRef.current;
+    const activeLink = nav?.querySelector<HTMLElement>(
+      '.toc-link[aria-current="location"]'
+    );
+
+    if (!nav || !activeLink) return;
+
+    const navRect = nav.getBoundingClientRect();
+    const activeLinkRect = activeLink.getBoundingClientRect();
+    const scrollPadding = 8;
+    let scrollDelta = 0;
+
+    if (activeLinkRect.top < navRect.top + scrollPadding) {
+      scrollDelta = activeLinkRect.top - navRect.top - scrollPadding;
+    } else if (activeLinkRect.bottom > navRect.bottom - scrollPadding) {
+      scrollDelta = activeLinkRect.bottom - navRect.bottom + scrollPadding;
+    }
+
+    if (scrollDelta !== 0) {
+      nav.scrollBy({
+        top: scrollDelta,
+        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches
+          ? 'auto'
+          : 'smooth',
+      });
+    }
+  }, [activeId]);
+
+  useEffect(() => {
     const handleScroll = () => setIsVisible(window.scrollY > 300);
     const handleResize = () => setIsMobile(window.innerWidth <= 1200);
 
@@ -163,7 +197,7 @@ const TableOfContentsMDX: React.FC<TableOfContentsMDXProps> = ({
         <div className='toc-header'>
           <h4>Table of Contents</h4>
         </div>
-        <nav className='toc-nav' aria-label='Table of contents'>
+        <nav ref={tocNavRef} className='toc-nav' aria-label='Table of contents'>
           <TOCList items={nestedHeadings} activeId={activeId} />
         </nav>
       </div>

--- a/src/app/blog/[slug]/TableOfContentsMDX.tsx
+++ b/src/app/blog/[slug]/TableOfContentsMDX.tsx
@@ -143,7 +143,7 @@ const TableOfContentsMDX: React.FC<TableOfContentsMDXProps> = ({
   }, [setupObserver, headings, minHeadings]);
 
   useEffect(() => {
-    if (!activeId) return;
+    if (!activeId || isMobile) return;
 
     const nav = tocNavRef.current;
     const activeLink = nav?.querySelector<HTMLElement>(
@@ -171,7 +171,7 @@ const TableOfContentsMDX: React.FC<TableOfContentsMDXProps> = ({
           : 'smooth',
       });
     }
-  }, [activeId]);
+  }, [activeId, isMobile]);
 
   useEffect(() => {
     const handleScroll = () => setIsVisible(window.scrollY > 300);

--- a/src/app/components/TableOfContents/TableOfContents.scss
+++ b/src/app/components/TableOfContents/TableOfContents.scss
@@ -16,8 +16,7 @@
   opacity: 0;
   visibility: hidden;
   transition: all 0.3s ease;
-  overflow-y: auto;
-  scroll-behavior: auto;
+  overflow: hidden;
 
   // Add full glassmorphism effects manually (preserving position: fixed)
   backdrop-filter: blur(15px);
@@ -30,7 +29,10 @@
     border-radius: 12px;
     padding: 1rem;
     min-height: 100%;
+    max-height: 60vh;
     position: relative;
+    display: flex;
+    flex-direction: column;
 
     // Glassmorphism gradient overlay
     &::before {
@@ -76,6 +78,7 @@
   }
 
   .toc-header {
+    flex-shrink: 0;
     margin-bottom: 1rem;
     padding-bottom: 0.5rem;
     border-bottom: 1px solid rgba(255, 255, 255, 0.1);
@@ -97,6 +100,10 @@
   }
 
   .toc-nav {
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+
     .toc-list {
       list-style: none;
       padding: 0;

--- a/src/lib/mdx/index.ts
+++ b/src/lib/mdx/index.ts
@@ -1,11 +1,19 @@
 import fs from 'fs';
 import path from 'path';
 import { cache } from 'react';
+import GithubSlugger from 'github-slugger';
+import { toString } from 'mdast-util-to-string';
+import remarkGfm from 'remark-gfm';
+import remarkMdx from 'remark-mdx';
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+import { visit } from 'unist-util-visit';
 import { BlogPost, TOCHeading } from './types';
 import { BlogMetadataSchema } from './schema';
 import { logger } from '@/app/utils/logger';
 
 const CONTENT_DIR = path.join(process.cwd(), 'content', 'blog');
+const mdxParser = unified().use(remarkParse).use(remarkMdx).use(remarkGfm);
 
 export function getBlogSlugs(): string[] {
   if (!fs.existsSync(CONTENT_DIR)) {
@@ -139,38 +147,27 @@ export function calculateReadingTime(content: string): {
   };
 }
 
-// Generate a heading ID matching rehype-slug / github-slugger output
-function slugifyHeading(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^\w\s-]/g, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
 export function getBlogHeadings(slug: string): TOCHeading[] {
   const contentPath = path.join(CONTENT_DIR, `${slug}.mdx`);
   if (!fs.existsSync(contentPath)) return [];
 
   const raw = fs.readFileSync(contentPath, 'utf-8');
-  // Strip fenced code blocks so lines like `# comment` inside code aren't treated as headings
-  const content = raw.replace(/```[\s\S]*?```/g, '');
-  const headingRegex = /^(#{1,4})\s+(.+)$/gm;
+  const tree = mdxParser.parse(raw);
   const headings: TOCHeading[] = [];
+  const slugger = new GithubSlugger();
 
-  let match;
-  while ((match = headingRegex.exec(content)) !== null) {
-    const hashes = match[1];
-    const headingText = match[2];
-    if (!hashes || !headingText) continue;
+  visit(tree, 'heading', (heading) => {
+    if (heading.depth > 4) return;
 
-    const level = hashes.length;
-    const text = headingText.trim();
-    const id = slugifyHeading(text);
+    const text = toString(heading).trim();
+    if (!text) return;
 
-    headings.push({ id, text, level });
-  }
+    headings.push({
+      id: slugger.slug(text),
+      text,
+      level: heading.depth,
+    });
+  });
 
   return headings;
 }


### PR DESCRIPTION
## Summary
- keep the active blog table-of-contents entry visible while readers scroll
- keep the TOC header fixed while the navigation list scrolls independently
- generate TOC heading IDs from the MDX AST using the same GitHub slugging behavior as rehype-slug
- tolerate isolated missing heading elements instead of disabling active-section tracking

## Validation
- pnpm lint
- SKIP_ENV_VALIDATION=true pnpm build
- pnpm exec prettier --check README.md src/app src/lib/mdx
- verified every fragment link across all 12 prerendered blog HTML files resolves to an existing ID
- git diff --check
